### PR TITLE
Tags dropdown for create event

### DIFF
--- a/src/app/components/Autocomplete.js
+++ b/src/app/components/Autocomplete.js
@@ -20,6 +20,7 @@ export function AsyncAutocomplete(props) {
     asyncSearch,
     children,
     prefetch = false,
+    multiple = false,
     debounced = true,
     label,
     required,
@@ -70,6 +71,7 @@ export function AsyncAutocomplete(props) {
         onOpen={() => setOpen(true)}
         onClose={() => setOpen(false)}
         value={value}
+        multiple={multiple}
         onChange={(e, newValue) => {
           setOpen(false);
           onChange(newValue);
@@ -118,5 +120,6 @@ AsyncAutocomplete.propTypes = {
   asyncSearch: PropTypes.func,
   value: PropTypes.any,
   required: PropTypes.bool,
+  multiple: PropTypes.bool,
   prefetch: PropTypes.bool,
 };

--- a/src/app/views/events/forms/EventForm.jsx
+++ b/src/app/views/events/forms/EventForm.jsx
@@ -32,6 +32,7 @@ const EventForm = () => {
     sync_with_eventbrite: false,
   });
   const [venue, setVenue] = useState(null);
+  const [tags, setTags] = useState([]);
   const [eventType, setEventType] = useState(null);
   const { id } = useParams();
   const history = useHistory();
@@ -338,6 +339,22 @@ const EventForm = () => {
                     variant="outlined"
                     value={values.excerpt}
                     onChange={handleChange}
+                  />
+                </Grid>
+                <Grid item md={1} sm={4} xs={12}>
+                  Tags
+                </Grid>
+                <Grid item md={3} sm={8} xs={12}>
+                  <AsyncAutocomplete
+                    onChange={(v) => setTags(v)}
+                    asyncSearch={() => bc.marketing().getAcademyTags()}
+                    size="small"
+                    label="Tags"
+                    debounced={false}
+                    multiple={true}
+                    required={false}
+                    getOptionLabel={(option) => `${option.slug}`}
+                    value={tags}
                   />
                 </Grid>
                 <Grid item md={1} sm={4} xs={12}>

--- a/src/app/views/events/forms/EventForm.jsx
+++ b/src/app/views/events/forms/EventForm.jsx
@@ -352,7 +352,7 @@ const EventForm = () => {
                     label="Tags"
                     debounced={false}
                     multiple={true}
-                    required={true}
+                    required={tags.length <= 1}
                     getOptionLabel={(option) => `${option.slug}`}
                     value={tags}
                   />

--- a/src/app/views/events/forms/EventForm.jsx
+++ b/src/app/views/events/forms/EventForm.jsx
@@ -352,10 +352,11 @@ const EventForm = () => {
                     label="Tags"
                     debounced={false}
                     multiple={true}
-                    required={false}
+                    required={true}
                     getOptionLabel={(option) => `${option.slug}`}
                     value={tags}
                   />
+                  <small className="text-muted">The specified tags will be applied to this event attendees on active campaign</small>
                 </Grid>
                 <Grid item md={1} sm={4} xs={12}>
                   Online Event


### PR DESCRIPTION
 - Added a AsyncAutoComplete component to the create Event view labeled tags to allow users to add tags to events form
 - Added a multiple option to the AutoComplete component set to false with a props option to activate in the component it will be used in
 - added small note under tags dropdown in the event form
 - made tags field required atleast 2 tags 