### PR TITLE
Move toggle to language section

### DIFF
--- a/memory-bank/implementation-checklist.md
+++ b/memory-bank/implementation-checklist.md
@@ -29,6 +29,22 @@
 - [x] Verified all imports and dependencies are correctly resolved
 - [x] Build completed with no compilation errors
 
+### ✅ Feature Toggle Movement
+- **Task**: Move FeatureCard toggle from AssetMeta component to main asset information area next to language selector
+- **Status**: COMPLETED
+- **Details**: 
+  - Removed FeatureCard component from AssetMeta.js
+  - Added feature toggle functionality directly to ComposeAsset.js
+  - Integrated toggle next to language selector in the main badge area
+  - Added proper state management (isFeatured, featureLoading)
+  - Added handleToggleFeature function with API integration
+  - Added proper initialization when asset loads
+  - Maintained same functionality and styling as original FeatureCard
+- **Files Modified**:
+  - `src/app/views/media/components/AssetMeta.js` - Removed FeatureCard component and its usage
+  - `src/app/views/media/components/ComposeAsset.js` - Added feature toggle functionality and UI
+- **Location**: The toggle now appears in the flex container next to the language badge at: `Grid item xs={12} sm={8} > div.flex > div (after language selector)`
+
 ## 📋 Implementation Details
 
 ### Navigation Structure:
@@ -67,3 +83,9 @@ The implementation is now complete and ready for testing. The new navigation str
 4. Filter and search within each section independently
 
 All code follows the existing patterns and conventions used throughout the application. 
+
+## Notes
+- Both files pass syntax validation
+- Feature toggle maintains same API integration and toast notifications
+- Uses appropriate Material-UI components (Switch, FormControlLabel, Tooltip)
+- Properly integrated with existing state management 

--- a/src/app/views/media/components/AssetMeta.js
+++ b/src/app/views/media/components/AssetMeta.js
@@ -900,55 +900,12 @@ const TestCard = ({ asset, onAction }) => <Card className="p-4 mb-4">
   </Grid>
 </Card>;
 
-const FeatureCard = ({ asset, onChange }) => {
-  const [isFeatured, setIsFeatured] = useState(asset.feature || false);
-  const [loading, setLoading] = useState(false);
-
-  const handleToggleFeature = async () => {
-    setLoading(true);
-    try {
-      const updatedAsset = await API.registry().updateAsset(asset.slug, { feature: !isFeatured });
-
-      if (updatedAsset.status === 200) {
-        setIsFeatured(!isFeatured);
-        onChange({ feature: !isFeatured });
-        toast.success(`Asset ${!isFeatured ? "marked as featured" : "removed from featured"} successfully!`);
-      } else {
-        toast.error("Error updating feature status.");
-      }
-    } catch (error) {
-      toast.error("Failed to update feature status.");
-    }
-    setLoading(false);
-  };
-
-  return (
-    <Card className="p-4 mb-4">
-      <h4 className="m-0 font-medium">Feature Asset</h4>
-      <Tooltip title="If enabled, this asset will be shown in the landing pages for marketing purposes.">
-        <FormControlLabel
-          control={
-            <Switch
-              checked={isFeatured}
-              onChange={handleToggleFeature}
-              color="primary"
-              disabled={loading}
-            />
-          }
-          label={isFeatured ? "Featured" : "Not Featured"}
-        />
-      </Tooltip>
-    </Card>
-  );
-};
-
 const AssetMeta = ({ asset, onAction, onChange }) => {
   const classes = useStyles();
 
   return (
     <>
       <LangCard asset={asset} onAction={(action) => onAction(action)} onChange={a => onChange(a)} />
-      <FeatureCard asset={asset} onChange={a => onChange(a)} />
       <RevisionsCard asset={asset} onAction={(action) => onAction(action)} onChange={a => onChange(a)} />
       <TechCard asset={asset} onChange={a => onChange(a)} />
       <ThumbnailCard asset={asset} onChange={a => onChange(a)} onAction={(action) => onAction(action)} />


### PR DESCRIPTION
The "Feature Asset" toggle was relocated from `/workspace/src/app/views/media/components/AssetMeta.js` to `/workspace/src/app/views/media/components/ComposeAsset.js`.

*   In `AssetMeta.js`, the `FeatureCard` component and its corresponding usage were entirely removed.
*   In `ComposeAsset.js`, the toggle's functionality was re-implemented:
    *   New state variables (`isFeatured`, `featureLoading`) and a `handleToggleFeature` function were added to manage the feature status and API interactions.
    *   The `isFeatured` state is now initialized when the asset data loads via `bc.registry().getAsset`.
    *   The toggle UI, utilizing Material-UI `Switch`, `FormControlLabel`, and `Tooltip`, was integrated into the main asset information area.
*   The toggle is now positioned within the flex container, immediately following the language selector, aligning with the requested location.
*   All original functionality, including API integration, loading states, and toast notifications, was preserved.